### PR TITLE
Add Groq inference provider

### DIFF
--- a/chatquest.py
+++ b/chatquest.py
@@ -12,6 +12,7 @@ from telegram.ext import Application, CommandHandler, ContextTypes
 from openai_client import OpenAIClient
 from together_client import TogetherClient
 from mistral_client import MistralClient
+from groq_client import GroqClient
 
 import imaging
 from world import World, Town, Place, NPC, Point, TownList, PlaceList, NPCList, GenImage
@@ -34,6 +35,7 @@ TELEGRAM_BOT_TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 TOGETHER_API_KEY = os.getenv('TOGETHER_API_KEY')
 MISTRAL_API_KEY = os.getenv('MISTRAL_API_KEY')
+GROQ_API_KEY = os.getenv('GROQ_API_KEY')
 
 world_dict = {}
 
@@ -168,6 +170,8 @@ async def new_game(update: Update, context: ContextTypes.DEFAULT_TYPE):
     #world.metaprompter = OpenAIClient(OPENAI_API_KEY)
     #world.ai = TogetherClient(TOGETHER_API_KEY)
     #world.metaprompter = TogetherClient(TOGETHER_API_KEY)
+    #world.ai = GroqClient(GROQ_API_KEY)
+    #world.metaprompter = GroqClient(GROQ_API_KEY)
     world.ai = MistralClient(MISTRAL_API_KEY)
     world.metaprompter = MistralClient(MISTRAL_API_KEY)
 

--- a/groq_client.py
+++ b/groq_client.py
@@ -1,0 +1,45 @@
+from groq import Groq
+import prompts
+from ai_client import AIClient
+
+class GroqClient(AIClient):
+    def __init__(self, api_key: str):
+        super().__init__("Groq")
+        self.client = Groq(api_key=api_key)
+        self.model = "llama3-70b-8192"
+
+    def init_chat(self):
+        self.messages = [
+            {"role": "system", "content": prompts.AGENT_ROLE}
+        ]
+        self.log_role(prompts.AGENT_ROLE)
+
+    def prompt(self, text: str):
+        self.messages.append({"role": "user", "content": text})
+        self.log_prompt(text)
+
+    def get_response(self):
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=self.messages,
+            temperature=1.0
+        )
+        text = response.choices[0].message.content
+        self.messages.append({"role": "assistant", "content": text})
+        return text
+
+    def get_json_response(self, type):
+        completion = self.client.chat.completions.create(
+            model=self.model,
+            messages=self.messages,
+            temperature=0,
+            response_format={
+                "type": "json_object",
+                "schema": type.model_json_schema(),
+            }
+        )
+        json_data = completion.choices[0].message.content
+        self.log_response_json(json_data)
+        data = type.model_validate_json(json_data)
+        self.log_response_object(data)
+        return data


### PR DESCRIPTION
## Summary
- implement `GroqClient` for Groq API integration
- register Groq token in `chatquest.py`
- allow Groq client in commented provider list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a54ea9d4c8321b05e241910c36702